### PR TITLE
Marker space calculation

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.12072261, g: 0.12473124, b: 0.10821977, a: 1}
+  m_IndirectSpecularColor: {r: 0.12072234, g: 0.12473106, b: 0.1082197, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -4445,6 +4445,114 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1010085204}
   m_CullTransparentMesh: 1
+--- !u!1001 &1012736715
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1928135998}
+    m_Modifications:
+    - target: {fileID: 9023931458948383120, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
+      propertyPath: m_Radius
+      value: 1.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 9023931458948383120, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
+      propertyPath: m_IsTrigger
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9023931458948383121, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: c9162dcbe5d17bc47be066984986ef3f, type: 2}
+    - target: {fileID: 9023931458948383125, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
+      propertyPath: m_Name
+      value: Debug Marker
+      objectReference: {fileID: 0}
+    - target: {fileID: 9023931458948383125, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.067979194
+      objectReference: {fileID: 0}
+    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.0679792
+      objectReference: {fileID: 0}
+    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.067979194
+      objectReference: {fileID: 0}
+    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.126
+      objectReference: {fileID: 0}
+    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.015
+      objectReference: {fileID: 0}
+    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
+--- !u!4 &1012736716 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
+  m_PrefabInstance: {fileID: 1012736715}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1012736717 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 9023931458948383125, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
+  m_PrefabInstance: {fileID: 1012736715}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1012736718
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1012736717}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ad37865ce79c1484b9361fe3b69d2116, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  shape: {fileID: 1859468958}
 --- !u!1 &1041344368
 GameObject:
   m_ObjectHideFlags: 0
@@ -8873,6 +8981,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   markerPrefab: {fileID: 9023931458948383125, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
+  pourTool: {fileID: 3452001473514026278}
+  maxDistance: 0.3
+  debugMarker: {fileID: 1012736717}
 --- !u!65 &1859468965
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -9299,6 +9410,7 @@ Transform:
   - {fileID: 1859468958}
   - {fileID: 1419568722}
   - {fileID: 262639188}
+  - {fileID: 1012736716}
   m_Father: {fileID: 2145211720}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -33093,6 +33205,11 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: f9cafb5da9e6e254db4a3469dfac5879, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7221e82caae3aaa4691f8fd74f800db1, type: 3}
+--- !u!1 &3452001473514026278 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3452001473513494095, guid: 7221e82caae3aaa4691f8fd74f800db1, type: 3}
+  m_PrefabInstance: {fileID: 3452001473514026277}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &3488850841514040821
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -4445,114 +4445,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1010085204}
   m_CullTransparentMesh: 1
---- !u!1001 &1012736715
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1928135998}
-    m_Modifications:
-    - target: {fileID: 9023931458948383120, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
-      propertyPath: m_Radius
-      value: 1.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 9023931458948383120, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
-      propertyPath: m_IsTrigger
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9023931458948383121, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: c9162dcbe5d17bc47be066984986ef3f, type: 2}
-    - target: {fileID: 9023931458948383125, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
-      propertyPath: m_Name
-      value: Debug Marker
-      objectReference: {fileID: 0}
-    - target: {fileID: 9023931458948383125, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
-      propertyPath: m_Layer
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 0.067979194
-      objectReference: {fileID: 0}
-    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 0.0679792
-      objectReference: {fileID: 0}
-    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 0.067979194
-      objectReference: {fileID: 0}
-    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.126
-      objectReference: {fileID: 0}
-    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.015
-      objectReference: {fileID: 0}
-    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
---- !u!4 &1012736716 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 9023931458948383126, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
-  m_PrefabInstance: {fileID: 1012736715}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1012736717 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 9023931458948383125, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
-  m_PrefabInstance: {fileID: 1012736715}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1012736718
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1012736717}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ad37865ce79c1484b9361fe3b69d2116, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  shape: {fileID: 1859468958}
 --- !u!1 &1041344368
 GameObject:
   m_ObjectHideFlags: 0
@@ -8983,7 +8875,6 @@ MonoBehaviour:
   markerPrefab: {fileID: 9023931458948383125, guid: 0de7616eb2174e54a8c8df6932f25d4e, type: 3}
   pourTool: {fileID: 3452001473514026278}
   maxDistance: 0.3
-  debugMarker: {fileID: 1012736717}
 --- !u!65 &1859468965
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -9410,7 +9301,6 @@ Transform:
   - {fileID: 1859468958}
   - {fileID: 1419568722}
   - {fileID: 262639188}
-  - {fileID: 1012736716}
   m_Father: {fileID: 2145211720}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/CoordinateSystem/CoordinateGenerator.cs
+++ b/Assets/Scripts/CoordinateSystem/CoordinateGenerator.cs
@@ -12,11 +12,6 @@ public class CoordinateGenerator : MonoBehaviour
 
     public UnityEvent afterShapeGenerated = new();
 
-    void Awake()
-    {
-        SongInfo.Instance.onMeasure.AddListener(GenerateShape);
-    }
-
     void Start()
     {
         GenerateShape();

--- a/Assets/Scripts/Music/SongInfo.cs
+++ b/Assets/Scripts/Music/SongInfo.cs
@@ -5,7 +5,7 @@ using UnityEngine.Events;
 
 public class SongInfo : Singleton<SongInfo>
 {
-    private uint bpm = 10u;
+    private uint bpm = 120u;
     private uint beatsPerMeasure = 4u;
 
     private float secondsPerBeat;

--- a/Assets/Scripts/Music/SongInfo.cs
+++ b/Assets/Scripts/Music/SongInfo.cs
@@ -5,7 +5,7 @@ using UnityEngine.Events;
 
 public class SongInfo : Singleton<SongInfo>
 {
-    private uint bpm = 120u;
+    private uint bpm = 10u;
     private uint beatsPerMeasure = 4u;
 
     private float secondsPerBeat;

--- a/Assets/Scripts/Music/SongInfo.cs
+++ b/Assets/Scripts/Music/SongInfo.cs
@@ -5,7 +5,7 @@ using UnityEngine.Events;
 
 public class SongInfo : Singleton<SongInfo>
 {
-    private uint bpm = 60u;
+    private uint bpm = 120u;
     private uint beatsPerMeasure = 4u;
 
     private float secondsPerBeat;

--- a/Assets/Scripts/Stations/PancakeStation/PancakeLineManager.cs
+++ b/Assets/Scripts/Stations/PancakeStation/PancakeLineManager.cs
@@ -12,17 +12,30 @@ public class PancakeLineManager : MonoBehaviour
     private LineRenderer lineRenderer;
     private GameObject marker;
     private Coroutine beatFollower;
+    private bool readyForNewMeasure = true;
 
     void Awake()
     {
         lineRenderer = GetComponent<LineRenderer>();
         coordinateGenerator = GetComponent<CoordinateGenerator>();
-        SongInfo.Instance.onMeasure.AddListener(DrawLine);
+        SongInfo.Instance.onMeasure.AddListener(NewMeasure);
     }
 
     void Start()
     {
         lineRenderer.useWorldSpace = false;
+    }
+
+    public void NewMeasure()
+    {
+        if (readyForNewMeasure)
+        {
+            readyForNewMeasure = false;
+            DrawLine();
+        } else
+        {
+            readyForNewMeasure = true;
+        }
     }
 
     public void DrawLine()

--- a/Assets/Scripts/Stations/PancakeStation/PancakeLineManager.cs
+++ b/Assets/Scripts/Stations/PancakeStation/PancakeLineManager.cs
@@ -123,15 +123,22 @@ public class PancakeLineManager : MonoBehaviour
         Vector3 mouseLocation = new Vector3(pourTool.transform.position.x, previous.y, pourTool.transform.position.z);
         Vector3 mouseOffset = mouseLocation - marker.transform.position;
         Vector3 tangentVector = Vector3.Normalize(next - previous);
-        float angle = Vector3.SignedAngle(mouseOffset, tangentVector, Vector3.up);
+        Vector3 leftTangent = Vector3.Cross(tangentVector, Vector3.up);
 
-        mouseOffset = Quaternion.Euler(0, angle, 0) * mouseOffset;
+        Vector3 frontProjection = Vector3.Project(mouseOffset, tangentVector);
+        Vector3 leftProjection = Vector3.Project(mouseOffset, leftTangent);
 
-        if (Vector3.Magnitude(mouseOffset) > maxDistance)
+        float frontDistance = frontProjection.magnitude;
+        if (Vector3.Angle(frontProjection, tangentVector) > 90)
         {
-            mouseOffset = maxDistance * Vector3.Normalize(mouseOffset);
+            frontDistance *= -1;
+        }
+        float leftDistance = leftProjection.magnitude;
+        if (Vector3.Angle(leftProjection, tangentVector) > 90)
+        {
+            leftDistance *= -1;
         }
 
-        Station.HandlePathUpdate(new Vector2(mouseOffset.x, mouseOffset.z));
+        Station.HandlePathUpdate(new Vector2(frontDistance, -leftDistance));
     }
 }

--- a/Assets/Scripts/Stations/PancakeStation/PancakeLineManager.cs
+++ b/Assets/Scripts/Stations/PancakeStation/PancakeLineManager.cs
@@ -66,22 +66,20 @@ public class PancakeLineManager : MonoBehaviour
         int totalBeats = lineRenderer.positionCount - 1;
         int halfBeats = 2 * (totalBeats - (int)SongInfo.Instance.getBeatsPerMeasure());
         int fullBeats = totalBeats - halfBeats;
-        int index = 0;
         float accumulatedTime = 0F;
-        float lastBeatTime = 0F;
         float beatProgress = 0F;
 
         marker = GameObject.Instantiate(markerPrefab, transform);
 
-        float beatDuration = SongInfo.Instance.getSecondsPerBeat();
+        float beatDuration = SongInfo.Instance.getSecondsPerBeat() * 2;
         List<CoordinateCollider> points = coordinateGenerator.GetColliders();
 
         while (accumulatedTime < (beatDuration * SongInfo.Instance.getBeatsPerMeasure()))
         {
             accumulatedTime += Time.deltaTime;
-            beatProgress = SongInfo.Instance.getBeatProgress();
+            beatProgress = accumulatedTime % beatDuration;
 
-            int beatsPassed = (int)SongInfo.Instance.getBeatsPassed();
+            int beatsPassed = Mathf.FloorToInt(accumulatedTime / beatDuration);
             if (beatsPassed >= SongInfo.Instance.getBeatsPerMeasure())
             {
                 beatsPassed = 0;
@@ -89,22 +87,21 @@ public class PancakeLineManager : MonoBehaviour
 
             if (beatsPassed < fullBeats)
             {
-                beatProgress = SongInfo.Instance.getBeatProgress();
                 Vector3 previous = points[beatsPassed].transform.position;
                 Vector3 next = points[beatsPassed+1].transform.position;
-                marker.transform.position = Vector3.Lerp(next, previous, beatProgress);
+                marker.transform.position = Vector3.Lerp(previous, next, beatProgress);
             } else
             {
                 if (beatProgress > 0.5)
                 {
-                    Vector3 previous = points[beatsPassed].transform.position;
-                    Vector3 next = points[beatsPassed+1].transform.position;
-                    marker.transform.position = Vector3.Lerp(next, previous, (beatProgress - 0.5F) * 2);
-                } else
-                {
                     Vector3 previous = points[beatsPassed+1].transform.position;
                     Vector3 next = points[beatsPassed+2].transform.position;
-                    marker.transform.position = Vector3.Lerp(next, previous, beatProgress * 2);
+                    marker.transform.position = Vector3.Lerp(previous, next, (beatProgress - 0.5F) * 2);
+                } else
+                {
+                    Vector3 previous = points[beatsPassed].transform.position;
+                    Vector3 next = points[beatsPassed+1].transform.position;
+                    marker.transform.position = Vector3.Lerp(previous, next, beatProgress * 2);
                 }
             }
 

--- a/Assets/Scripts/Stations/PancakeStation/PancakeLineManager.cs
+++ b/Assets/Scripts/Stations/PancakeStation/PancakeLineManager.cs
@@ -24,6 +24,7 @@ public class PancakeLineManager : MonoBehaviour
     void Start()
     {
         lineRenderer.useWorldSpace = false;
+        NewMeasure();
     }
 
     public void NewMeasure()

--- a/Assets/Scripts/Stations/PancakeStation/PancakeLineManager.cs
+++ b/Assets/Scripts/Stations/PancakeStation/PancakeLineManager.cs
@@ -82,7 +82,7 @@ public class PancakeLineManager : MonoBehaviour
         while (accumulatedTime < (beatDuration * SongInfo.Instance.getBeatsPerMeasure()))
         {
             accumulatedTime += Time.deltaTime;
-            beatProgress = accumulatedTime % beatDuration;
+            beatProgress = (accumulatedTime % beatDuration) / beatDuration;
 
             int beatsPassed = Mathf.FloorToInt(accumulatedTime / beatDuration);
             if (beatsPassed >= SongInfo.Instance.getBeatsPerMeasure())

--- a/Assets/Scripts/Stations/PancakeStation/PancakeLineManager.cs
+++ b/Assets/Scripts/Stations/PancakeStation/PancakeLineManager.cs
@@ -17,7 +17,7 @@ public class PancakeLineManager : MonoBehaviour
     {
         lineRenderer = GetComponent<LineRenderer>();
         coordinateGenerator = GetComponent<CoordinateGenerator>();
-        coordinateGenerator.afterShapeGenerated.AddListener(DrawLine);
+        SongInfo.Instance.onMeasure.AddListener(DrawLine);
     }
 
     void Start()
@@ -27,6 +27,7 @@ public class PancakeLineManager : MonoBehaviour
 
     public void DrawLine()
     {
+        coordinateGenerator.GenerateShape();
         GameObject.Destroy(marker);
         marker = null;
         if (beatFollower != null)

--- a/Assets/Scripts/Stations/PancakeStation/PancakeLineManager.cs
+++ b/Assets/Scripts/Stations/PancakeStation/PancakeLineManager.cs
@@ -10,8 +10,6 @@ public class PancakeLineManager : MonoBehaviour
     [SerializeField] private GameObject pourTool;
     [SerializeField] private float maxDistance = 0.3F;
 
-    public GameObject debugMarker;
-
     private CoordinateGenerator coordinateGenerator;
     private LineRenderer lineRenderer;
     private GameObject marker;
@@ -146,8 +144,6 @@ public class PancakeLineManager : MonoBehaviour
         {
             markerSpace = maxDistance * markerSpace.normalized;
         }
-
-        debugMarker.transform.position = marker.transform.position + new Vector3(-markerSpace.y, 0, -markerSpace.x);
 
         Station.HandlePathUpdate(markerSpace);
     }

--- a/Assets/Scripts/Stations/PancakeStation/PancakeLineManager.cs
+++ b/Assets/Scripts/Stations/PancakeStation/PancakeLineManager.cs
@@ -10,6 +10,8 @@ public class PancakeLineManager : MonoBehaviour
     [SerializeField] private GameObject pourTool;
     [SerializeField] private float maxDistance = 0.3F;
 
+    public GameObject debugMarker;
+
     private CoordinateGenerator coordinateGenerator;
     private LineRenderer lineRenderer;
     private GameObject marker;
@@ -138,6 +140,8 @@ public class PancakeLineManager : MonoBehaviour
         {
             leftDistance *= -1;
         }
+
+        debugMarker.transform.position = marker.transform.position + new Vector3(-leftDistance, 0, frontDistance);
 
         Station.HandlePathUpdate(new Vector2(frontDistance, -leftDistance));
     }

--- a/Assets/Scripts/Stations/PancakeStation/PancakeLineManager.cs
+++ b/Assets/Scripts/Stations/PancakeStation/PancakeLineManager.cs
@@ -136,13 +136,19 @@ public class PancakeLineManager : MonoBehaviour
             frontDistance *= -1;
         }
         float leftDistance = leftProjection.magnitude;
-        if (Vector3.Angle(leftProjection, tangentVector) > 90)
+        if (Vector3.Angle(leftProjection, leftTangent) > 90)
         {
             leftDistance *= -1;
         }
 
-        debugMarker.transform.position = marker.transform.position + new Vector3(-leftDistance, 0, frontDistance);
+        Vector2 markerSpace = new Vector2(frontDistance, -leftDistance);
+        if (markerSpace.magnitude > maxDistance)
+        {
+            markerSpace = maxDistance * markerSpace.normalized;
+        }
 
-        Station.HandlePathUpdate(new Vector2(frontDistance, -leftDistance));
+        debugMarker.transform.position = marker.transform.position + new Vector3(-markerSpace.y, 0, -markerSpace.x);
+
+        Station.HandlePathUpdate(markerSpace);
     }
 }

--- a/Assets/Scripts/Stations/Station.cs
+++ b/Assets/Scripts/Stations/Station.cs
@@ -33,6 +33,11 @@ public abstract class Station : MonoBehaviour
         //Composer.Instance.PitchChange(pitch);
     }
 
+    public static void HandlePathUpdate(Vector2 offset)
+    {
+        // TODO: this.
+    }
+
     public Camera GetAssociatedCamera() { return associatedCamera; }
     public bool IsRunning() { return running; }
 }


### PR DESCRIPTION
The pancake coroutine will now send continuous update calls to let the station know where the mouse is relative to the marker's forward space. +X is ahead, +Y is to the right. This does not have tangible effects yet.

In other news, the pancake station now does its shape over the course of two measures. But I also sped the BPM back up so this doesn't have tangible effects either.