### PR TITLE
Asset swapping

### DIFF
--- a/Assets/Scenes/AssetSwappingTestScene.unity
+++ b/Assets/Scenes/AssetSwappingTestScene.unity
@@ -504,3 +504,48 @@ MonoBehaviour:
   m_ShadowLayerMask: 1
   m_LightCookieSize: {x: 1, y: 1}
   m_LightCookieOffset: {x: 0, y: 0}
+--- !u!1 &1278972039
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1278972041}
+  - component: {fileID: 1278972040}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1278972040
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1278972039}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db532104ece27d44b880f8881d381d37, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  testTarget: Test Cube
+--- !u!4 &1278972041
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1278972039}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.8626034, y: 3.568103, z: 0.39846388}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/AssetSwappingTestScene.unity
+++ b/Assets/Scenes/AssetSwappingTestScene.unity
@@ -1,0 +1,506 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.18028352, g: 0.22571376, b: 0.30692244, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &919720642
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 919720649}
+  - component: {fileID: 919720648}
+  - component: {fileID: 919720647}
+  - component: {fileID: 919720646}
+  - component: {fileID: 919720645}
+  - component: {fileID: 919720644}
+  - component: {fileID: 919720643}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &919720643
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 919720642}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 362a24ac25afdb54591e9d3b831b8d61, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  name: Cyan
+  mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+  material: {fileID: 2100000, guid: 689af64514965f54ea92eecf6a6650b5, type: 2}
+--- !u!114 &919720644
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 919720642}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 362a24ac25afdb54591e9d3b831b8d61, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  name: Sphere
+  mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+  material: {fileID: 2100000, guid: 3e1729ac153fc774b87cf4a954499c01, type: 2}
+--- !u!114 &919720645
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 919720642}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 362a24ac25afdb54591e9d3b831b8d61, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  name: Default
+  mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+  material: {fileID: 2100000, guid: 236e02265ae2ab548be77c9c36e017ef, type: 2}
+--- !u!114 &919720646
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 919720642}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a1f0687dcec207a47a86c166d57b107d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  assetName: Test Cube
+  defaultVariant: {fileID: 919720645}
+  meshFilter: {fileID: 919720648}
+  meshRenderer: {fileID: 919720647}
+--- !u!23 &919720647
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 919720642}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 236e02265ae2ab548be77c9c36e017ef, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &919720648
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 919720642}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &919720649
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 919720642}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.5482247, y: 2.192292, z: 3.3386915}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &924962291
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 924962294}
+  - component: {fileID: 924962293}
+  - component: {fileID: 924962292}
+  - component: {fileID: 924962295}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &924962292
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 924962291}
+  m_Enabled: 1
+--- !u!20 &924962293
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 924962291}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &924962294
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 924962291}
+  m_LocalRotation: {x: 0.17735071, y: -0.26215357, z: 0.049078636, w: 0.94731915}
+  m_LocalPosition: {x: 2.846, y: 2.93, z: 1.268}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 21.208, y: -30.937, z: 0}
+--- !u!114 &924962295
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 924962291}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+--- !u!1 &935146993
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 935146995}
+  - component: {fileID: 935146994}
+  - component: {fileID: 935146996}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &935146994
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 935146993}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &935146995
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 935146993}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!114 &935146996
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 935146993}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 1
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}

--- a/Assets/Scenes/AssetSwappingTestScene.unity.meta
+++ b/Assets/Scenes/AssetSwappingTestScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f662c730465e7624c8ae6c83d81efbd4
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Cosmetics.meta
+++ b/Assets/Scripts/Cosmetics.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 78109f6c524e9e04c98a94a080616d1c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Cosmetics/AssetManager.cs
+++ b/Assets/Scripts/Cosmetics/AssetManager.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public static class AssetManager
 {
-    private static Dictionary<string, List<AssetSwapper>> assets;
+    private static Dictionary<string, List<AssetSwapper>> assets = new();
 
     public static void RegisterAsset(AssetSwapper asset) {
         string id = asset.assetName;

--- a/Assets/Scripts/Cosmetics/AssetManager.cs
+++ b/Assets/Scripts/Cosmetics/AssetManager.cs
@@ -1,0 +1,36 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class AssetManager
+{
+    private static Dictionary<string, List<AssetSwapper>> assets;
+
+    public static void RegisterAsset(AssetSwapper asset) {
+        string id = asset.assetName;
+        if (!assets.ContainsKey(id))
+        {
+            assets.Add(id, new List<AssetSwapper>());
+        }
+        assets[id].Add(asset);
+    }
+
+    public static ICollection<string> GetAssetNames()
+    {
+        return assets.Keys;
+    }
+
+    public static ICollection<string> GetAvailableSwapsForAsset(string targetAssetName)
+    {
+        AssetSwapper asset = assets[targetAssetName][0];
+        return asset.GetVariantOptionNames();
+    }
+
+    public static void ApplyAssetSwap(string assetName, string variantName)
+    {
+        foreach (AssetSwapper swapper in assets[assetName])
+        {
+            swapper.ApplyVariant(variantName);
+        }
+    }
+}

--- a/Assets/Scripts/Cosmetics/AssetManager.cs.meta
+++ b/Assets/Scripts/Cosmetics/AssetManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 90e6ca6d4a0a90c45bec729df9cdd2dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Cosmetics/AssetSwapper.cs
+++ b/Assets/Scripts/Cosmetics/AssetSwapper.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AssetSwapper : MonoBehaviour
+{
+    public int assetId;
+    public string assetName;
+
+    private List<AssetVariant> variantOptions;
+    [SerializeField] private AssetVariant defaultVariant;
+    [SerializeField] private MeshFilter meshFilter;
+    [SerializeField] private MeshRenderer meshRenderer;
+
+    void Awake()
+    {
+        foreach (AssetVariant variant in variantOptions)
+        {
+            variant.SetFilterAndRenderer(meshFilter, meshRenderer);
+        }
+    }
+}

--- a/Assets/Scripts/Cosmetics/AssetSwapper.cs
+++ b/Assets/Scripts/Cosmetics/AssetSwapper.cs
@@ -4,19 +4,29 @@ using UnityEngine;
 
 public class AssetSwapper : MonoBehaviour
 {
-    public int assetId;
     public string assetName;
 
-    private List<AssetVariant> variantOptions;
+    private Dictionary<string, AssetVariant> variantOptions;
     [SerializeField] private AssetVariant defaultVariant;
     [SerializeField] private MeshFilter meshFilter;
     [SerializeField] private MeshRenderer meshRenderer;
 
     void Awake()
     {
-        foreach (AssetVariant variant in variantOptions)
+        foreach (AssetVariant variant in variantOptions.Values)
         {
             variant.SetFilterAndRenderer(meshFilter, meshRenderer);
         }
+
+        AssetManager.RegisterAsset(this);
+    }
+
+    public ICollection<string> GetVariantOptionNames() {
+        return variantOptions.Keys;
+    }
+
+    public void ApplyVariant(string swapName)
+    {
+        variantOptions[swapName].Apply();
     }
 }

--- a/Assets/Scripts/Cosmetics/AssetSwapper.cs
+++ b/Assets/Scripts/Cosmetics/AssetSwapper.cs
@@ -6,7 +6,7 @@ public class AssetSwapper : MonoBehaviour
 {
     public string assetName;
 
-    private Dictionary<string, AssetVariant> variantOptions;
+    private Dictionary<string, AssetVariant> variantOptions = new();
     [SerializeField] private AssetVariant defaultVariant;
     [SerializeField] private MeshFilter meshFilter;
     [SerializeField] private MeshRenderer meshRenderer;

--- a/Assets/Scripts/Cosmetics/AssetSwapper.cs
+++ b/Assets/Scripts/Cosmetics/AssetSwapper.cs
@@ -13,9 +13,10 @@ public class AssetSwapper : MonoBehaviour
 
     void Awake()
     {
-        foreach (AssetVariant variant in variantOptions.Values)
+        foreach (AssetVariant variant in GetComponents<AssetVariant>())
         {
             variant.SetFilterAndRenderer(meshFilter, meshRenderer);
+            variantOptions.Add(variant.name, variant);
         }
 
         AssetManager.RegisterAsset(this);

--- a/Assets/Scripts/Cosmetics/AssetSwapper.cs
+++ b/Assets/Scripts/Cosmetics/AssetSwapper.cs
@@ -22,6 +22,11 @@ public class AssetSwapper : MonoBehaviour
         AssetManager.RegisterAsset(this);
     }
 
+    void Start()
+    {
+        defaultVariant.Apply();
+    }
+
     public ICollection<string> GetVariantOptionNames() {
         return variantOptions.Keys;
     }

--- a/Assets/Scripts/Cosmetics/AssetSwapper.cs.meta
+++ b/Assets/Scripts/Cosmetics/AssetSwapper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1f0687dcec207a47a86c166d57b107d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Cosmetics/AssetVariant.cs
+++ b/Assets/Scripts/Cosmetics/AssetVariant.cs
@@ -1,0 +1,26 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[RequireComponent(typeof(AssetSwapper))]
+public class AssetVariant : MonoBehaviour
+{
+    public string name;
+    public Mesh mesh;
+    public Material material;
+
+    private MeshFilter meshFilter;
+    private MeshRenderer meshRenderer;
+
+    public void SetFilterAndRenderer(MeshFilter filter, MeshRenderer renderer)
+    {
+        meshFilter = filter;
+        meshRenderer = renderer;
+    }
+
+    void Apply()
+    {
+        meshFilter.mesh = mesh;
+        meshRenderer.material = material;
+    }
+}

--- a/Assets/Scripts/Cosmetics/AssetVariant.cs
+++ b/Assets/Scripts/Cosmetics/AssetVariant.cs
@@ -18,7 +18,7 @@ public class AssetVariant : MonoBehaviour
         meshRenderer = renderer;
     }
 
-    void Apply()
+    public void Apply()
     {
         meshFilter.mesh = mesh;
         meshRenderer.material = material;

--- a/Assets/Scripts/Cosmetics/AssetVariant.cs.meta
+++ b/Assets/Scripts/Cosmetics/AssetVariant.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 362a24ac25afdb54591e9d3b831b8d61
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Cosmetics/TestAssetSwapping.cs
+++ b/Assets/Scripts/Cosmetics/TestAssetSwapping.cs
@@ -21,8 +21,8 @@ public class TestAssetSwapping : MonoBehaviour
         {
             foreach (string swap in swaps) {
                 AssetManager.ApplyAssetSwap(asset, swap);
+                yield return new WaitForSeconds(2);
             }
-            yield return new WaitForSeconds(2);
         }
     }
 }

--- a/Assets/Scripts/Cosmetics/TestAssetSwapping.cs
+++ b/Assets/Scripts/Cosmetics/TestAssetSwapping.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TestAssetSwapping : MonoBehaviour
+{
+    [SerializeField] private string testTarget;
+
+    void Start()
+    {
+        StartCoroutine(testRoutine());
+    }
+
+    private IEnumerator testRoutine()
+    {
+        string asset = testTarget;
+        ICollection<string> swaps = AssetManager.GetAvailableSwapsForAsset(asset);
+        int i = 0;
+
+        while (true)
+        {
+            foreach (string swap in swaps) {
+                AssetManager.ApplyAssetSwap(asset, swap);
+            }
+            yield return new WaitForSeconds(2);
+        }
+    }
+}

--- a/Assets/Scripts/Cosmetics/TestAssetSwapping.cs.meta
+++ b/Assets/Scripts/Cosmetics/TestAssetSwapping.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db532104ece27d44b880f8881d381d37
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
There is now a system for swapping meshes and/or materials of assets. Each potential swap defines a mesh and a material so that a mesh swap and a material swap cannot be stacked together. For a demonstration, see the new AssetSwappingTestScene, which will switch to the next of a set of three swaps every two seconds.

If multiple assets share the same swapper name, they will swap together when instructed by the manager, as it takes a name as input when swapping. Make sure they all have the same set of variant names, though.